### PR TITLE
Remove direct child selector from generated styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const resolveOptions = userOptions => {
 
 module.exports = () => ({ addBase, theme }) => {
   const addBaseStyles = (wrapperClass, elem, values) => {
-    const wrapper = wrapperClass ? `.${wrapperClass} > ` : '';
+    const wrapper = wrapperClass ? `.${wrapperClass} ` : '';
 
     addBase({
       [`${wrapper}${elem}`]: values,

--- a/stubs/output-with-additional-elements.css
+++ b/stubs/output-with-additional-elements.css
@@ -1,61 +1,61 @@
-.markdown > h1 {
+.markdown h1 {
   font-size: 4rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h2 {
+.markdown h2 {
   font-size: 1.875rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h3 {
+.markdown h3 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h4 {
+.markdown h4 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h5 {
+.markdown h5 {
   font-size: 1.125rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h6 {
+.markdown h6 {
   font-size: 1rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > p {
+.markdown p {
   margin-top: 4rem;
   margin-bottom: 1rem;
 }
 
-.markdown > a {
+.markdown a {
   color: #4299e1;
   text-decoration: none;
 }
 
-.markdown > a:hover {
+.markdown a:hover {
   color: #3182ce;
   text-decoration: none;
 }
 
-.markdown > blockquote {
+.markdown blockquote {
   border-color: #e2e8f0;
   border-left-width: 4px;
   font-weight: 400;
@@ -67,7 +67,7 @@
   font-size: 1.125rem;
 }
 
-.markdown > code {
+.markdown code {
   background-color: #e2e8f0;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -77,7 +77,7 @@
   font-size: 0.875rem;
 }
 
-.markdown > hr {
+.markdown hr {
   border-bottom-width: 1px;
   border-color: #e2e8f0;
   margin-top: 3rem;
@@ -85,23 +85,23 @@
   border-radius: 9999px;
 }
 
-.markdown > ul {
+.markdown ul {
   list-style-type: disc;
   list-style-position: inside;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.markdown > ol {
+.markdown ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.markdown > table {
+.markdown table {
   padding: 0;
 }
 
-.markdown > table tr {
+.markdown table tr {
   border-top-width: 1px;
   border-color: #4a5568;
   background-color: #fff;
@@ -109,11 +109,11 @@
   padding: 0;
 }
 
-.markdown > table tr:nth-child(2n) {
+.markdown table tr:nth-child(2n) {
   background-color: #f7fafc;
 }
 
-.markdown > table tr th {
+.markdown table tr th {
   font-weight: 700;
   border-width: 1px;
   border-color: #4a5568;
@@ -122,15 +122,15 @@
   padding: 6px 13px;
 }
 
-.markdown > table tr th:first-child {
+.markdown table tr th:first-child {
   margin-top: 0;
 }
 
-.markdown > table tr th:last-child {
+.markdown table tr th:last-child {
   margin-bottom: 0;
 }
 
-.markdown > table tr td {
+.markdown table tr td {
   border-width: 1px;
   border-color: #4a5568;
   text-align: left;
@@ -138,14 +138,14 @@
   padding: 6px 13px;
 }
 
-.markdown > table tr td:first-child {
+.markdown table tr td:first-child {
   margin-top: 0;
 }
 
-.markdown > table tr td:last-child {
+.markdown table tr td:last-child {
   margin-bottom: 0;
 }
 
-.markdown > img {
+.markdown img {
   width: 100%;
 }

--- a/stubs/output-with-custom-config.css
+++ b/stubs/output-with-custom-config.css
@@ -1,61 +1,61 @@
-.markdown > h1 {
+.markdown h1 {
   font-size: 4rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h2 {
+.markdown h2 {
   font-size: 1.875rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h3 {
+.markdown h3 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h4 {
+.markdown h4 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h5 {
+.markdown h5 {
   font-size: 1.125rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h6 {
+.markdown h6 {
   font-size: 1rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > p {
+.markdown p {
   margin-top: 4rem;
   margin-bottom: 1rem;
 }
 
-.markdown > a {
+.markdown a {
   color: #4299e1;
   text-decoration: none;
 }
 
-.markdown > a:hover {
+.markdown a:hover {
   color: #3182ce;
   text-decoration: none;
 }
 
-.markdown > blockquote {
+.markdown blockquote {
   border-color: #e2e8f0;
   border-left-width: 4px;
   font-weight: 400;
@@ -67,7 +67,7 @@
   font-size: 1.125rem;
 }
 
-.markdown > code {
+.markdown code {
   background-color: #e2e8f0;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -77,7 +77,7 @@
   font-size: 0.875rem;
 }
 
-.markdown > hr {
+.markdown hr {
   border-bottom-width: 1px;
   border-color: #e2e8f0;
   margin-top: 3rem;
@@ -85,23 +85,23 @@
   border-radius: 9999px;
 }
 
-.markdown > ul {
+.markdown ul {
   list-style-type: disc;
   list-style-position: inside;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.markdown > ol {
+.markdown ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.markdown > table {
+.markdown table {
   padding: 0;
 }
 
-.markdown > table tr {
+.markdown table tr {
   border-top-width: 1px;
   border-color: #4a5568;
   background-color: #fff;
@@ -109,11 +109,11 @@
   padding: 0;
 }
 
-.markdown > table tr:nth-child(2n) {
+.markdown table tr:nth-child(2n) {
   background-color: #f7fafc;
 }
 
-.markdown > table tr th {
+.markdown table tr th {
   font-weight: 700;
   border-width: 1px;
   border-color: #4a5568;
@@ -122,15 +122,15 @@
   padding: 6px 13px;
 }
 
-.markdown > table tr th:first-child {
+.markdown table tr th:first-child {
   margin-top: 0;
 }
 
-.markdown > table tr th:last-child {
+.markdown table tr th:last-child {
   margin-bottom: 0;
 }
 
-.markdown > table tr td {
+.markdown table tr td {
   border-width: 1px;
   border-color: #4a5568;
   text-align: left;
@@ -138,10 +138,10 @@
   padding: 6px 13px;
 }
 
-.markdown > table tr td:first-child {
+.markdown table tr td:first-child {
   margin-top: 0;
 }
 
-.markdown > table tr td:last-child {
+.markdown table tr td:last-child {
   margin-bottom: 0;
 }

--- a/stubs/output-with-custom-wrapper-class.css
+++ b/stubs/output-with-custom-wrapper-class.css
@@ -1,61 +1,61 @@
-.content > h1 {
+.content h1 {
   font-size: 2.25rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.content > h2 {
+.content h2 {
   font-size: 1.875rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.content > h3 {
+.content h3 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.content > h4 {
+.content h4 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.content > h5 {
+.content h5 {
   font-size: 1.125rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.content > h6 {
+.content h6 {
   font-size: 1rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.content > p {
+.content p {
   margin-top: 0;
   margin-bottom: 1rem;
 }
 
-.content > a {
+.content a {
   color: #4299e1;
   text-decoration: none;
 }
 
-.content > a:hover {
+.content a:hover {
   color: #3182ce;
   text-decoration: none;
 }
 
-.content > blockquote {
+.content blockquote {
   border-color: #e2e8f0;
   border-left-width: 4px;
   font-weight: 400;
@@ -67,7 +67,7 @@
   font-size: 1.125rem;
 }
 
-.content > code {
+.content code {
   background-color: #e2e8f0;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -77,7 +77,7 @@
   font-size: 0.875rem;
 }
 
-.content > hr {
+.content hr {
   border-bottom-width: 1px;
   border-color: #e2e8f0;
   margin-top: 3rem;
@@ -85,23 +85,23 @@
   border-radius: 9999px;
 }
 
-.content > ul {
+.content ul {
   list-style-type: disc;
   list-style-position: inside;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.content > ol {
+.content ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.content > table {
+.content table {
   padding: 0;
 }
 
-.content > table tr {
+.content table tr {
   border-top-width: 1px;
   border-color: #4a5568;
   background-color: #fff;
@@ -109,11 +109,11 @@
   padding: 0;
 }
 
-.content > table tr:nth-child(2n) {
+.content table tr:nth-child(2n) {
   background-color: #f7fafc;
 }
 
-.content > table tr th {
+.content table tr th {
   font-weight: 700;
   border-width: 1px;
   border-color: #4a5568;
@@ -122,15 +122,15 @@
   padding: 6px 13px;
 }
 
-.content > table tr th:first-child {
+.content table tr th:first-child {
   margin-top: 0;
 }
 
-.content > table tr th:last-child {
+.content table tr th:last-child {
   margin-bottom: 0;
 }
 
-.content > table tr td {
+.content table tr td {
   border-width: 1px;
   border-color: #4a5568;
   text-align: left;
@@ -138,10 +138,10 @@
   padding: 6px 13px;
 }
 
-.content > table tr td:first-child {
+.content table tr td:first-child {
   margin-top: 0;
 }
 
-.content > table tr td:last-child {
+.content table tr td:last-child {
   margin-bottom: 0;
 }

--- a/stubs/output.css
+++ b/stubs/output.css
@@ -1,61 +1,61 @@
-.markdown > h1 {
+.markdown h1 {
   font-size: 2.25rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h2 {
+.markdown h2 {
   font-size: 1.875rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h3 {
+.markdown h3 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h4 {
+.markdown h4 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h5 {
+.markdown h5 {
   font-size: 1.125rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > h6 {
+.markdown h6 {
   font-size: 1rem;
   font-weight: 700;
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
 
-.markdown > p {
+.markdown p {
   margin-top: 0;
   margin-bottom: 1rem;
 }
 
-.markdown > a {
+.markdown a {
   color: #4299e1;
   text-decoration: none;
 }
 
-.markdown > a:hover {
+.markdown a:hover {
   color: #3182ce;
   text-decoration: none;
 }
 
-.markdown > blockquote {
+.markdown blockquote {
   border-color: #e2e8f0;
   border-left-width: 4px;
   font-weight: 400;
@@ -67,7 +67,7 @@
   font-size: 1.125rem;
 }
 
-.markdown > code {
+.markdown code {
   background-color: #e2e8f0;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -77,7 +77,7 @@
   font-size: 0.875rem;
 }
 
-.markdown > hr {
+.markdown hr {
   border-bottom-width: 1px;
   border-color: #e2e8f0;
   margin-top: 3rem;
@@ -85,23 +85,23 @@
   border-radius: 9999px;
 }
 
-.markdown > ul {
+.markdown ul {
   list-style-type: disc;
   list-style-position: inside;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.markdown > ol {
+.markdown ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.markdown > table {
+.markdown table {
   padding: 0;
 }
 
-.markdown > table tr {
+.markdown table tr {
   border-top-width: 1px;
   border-color: #4a5568;
   background-color: #fff;
@@ -109,11 +109,11 @@
   padding: 0;
 }
 
-.markdown > table tr:nth-child(2n) {
+.markdown table tr:nth-child(2n) {
   background-color: #f7fafc;
 }
 
-.markdown > table tr th {
+.markdown table tr th {
   font-weight: 700;
   border-width: 1px;
   border-color: #4a5568;
@@ -122,15 +122,15 @@
   padding: 6px 13px;
 }
 
-.markdown > table tr th:first-child {
+.markdown table tr th:first-child {
   margin-top: 0;
 }
 
-.markdown > table tr th:last-child {
+.markdown table tr th:last-child {
   margin-bottom: 0;
 }
 
-.markdown > table tr td {
+.markdown table tr td {
   border-width: 1px;
   border-color: #4a5568;
   text-align: left;
@@ -138,10 +138,10 @@
   padding: 6px 13px;
 }
 
-.markdown > table tr td:first-child {
+.markdown table tr td:first-child {
   margin-top: 0;
 }
 
-.markdown > table tr td:last-child {
+.markdown table tr td:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
This fixes #1 by removing the direct child selector from generated styles. Tests were updated to reflect this change.